### PR TITLE
Fix out-of-tree building

### DIFF
--- a/cmake/executable.cmake
+++ b/cmake/executable.cmake
@@ -10,6 +10,7 @@ if (NOT BUILDING_SDK)
         ### source code sdk
         include_directories(${SDK_ROOT}/lib/arch/include ${SDK_ROOT}/lib/utils/include)
         add_subdirectory(${SDK_ROOT}/lib SDK)
+	add_subdirectory(${SDK_ROOT}/third_party THIRD_PARTY)
     endif()
 endif ()
 


### PR DESCRIPTION
Pull request for the patch provided in issue #30. In tree building still appears to work fine with this change, so I can only assume it doesn't have any side effects.

- [x] I have thoroughly tested my contribution.
- [x] The code I submitted has no copyright issues.

Out of tree project building failed because the third_party libraries within the sdk weren't included in the sdks cmake files.