### PR TITLE
Increase alignment of eh_frame from 8 to 32 bytes

### DIFF
--- a/lds/kendryte.ld
+++ b/lds/kendryte.ld
@@ -90,7 +90,7 @@ SECTIONS
   .eh_frame :
   {
     KEEP (*(.eh_frame)) *(.eh_frame.*)
-    . = ALIGN(8);
+    . = ALIGN(32);
   } > ram : DATA
   .gnu_extab : { *(.gnu_extab) } > ram : DATA
   .gcc_except_table : { *(.gcc_except_table .gcc_except_table.*) } > ram : DATA


### PR DESCRIPTION
Fixes #65 

- [x] I have thoroughly tested my contribution.
- [x] The code I submitted has no copyright issues.

Fixes fatal sys_exit when exceptions are throw from C++ code.